### PR TITLE
#7 Remove frontend enqueued scripts

### DIFF
--- a/outline.php
+++ b/outline.php
@@ -24,8 +24,8 @@ class EditorOutline {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'register_user_meta' ) );
-		add_action( 'enqueue_block_assets', array( $this, 'add_editor_assets' ) );
-		add_action( 'enqueue_block_assets', array( $this, 'add_init_scripts' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'add_editor_assets' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'add_init_scripts' ) );
 	}
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,10 @@ you can return a modified array.
 Check github repo for more information. https://github.com/kalimahapps/Editor-Block-Outline#filters
 
 == Changelog ==
+
+== 1.4.0 ==
+- Remove editor scripts from the frontend of the site
+
 = 1.3.2 =
 - Updated and fixed compatibility issues with WordPress 6.5
 


### PR DESCRIPTION
Resolves #7 .

I've switched the enqueueing actions to use `enqueue_block_editor_assets` instead of `enqueue_block_assets`. All seems to be working as expected on my local site.

I've also updated the changelog, I've gone to 1.4.0 since this does change behaviour in the unlikely event that someone is depending on these scripts in the frontend.